### PR TITLE
Fix small button issue on smaller screens

### DIFF
--- a/lib/intro_slider.dart
+++ b/lib/intro_slider.dart
@@ -922,7 +922,7 @@ class IntroSliderState extends State<IntroSlider>
                       ),
                     ) :
                     Flexible(
-                        flex: 3,
+                        flex: 4,
                         key: Key('$isChecked'),
                         child: Container(
                           decoration:  BoxDecoration(
@@ -947,9 +947,9 @@ class IntroSliderState extends State<IntroSlider>
                           ),
                           padding: EdgeInsets.symmetric(
                               vertical: 0.0.h, horizontal: 8.0.w),
-                          margin: EdgeInsets.only(bottom: 16.0),
+                          margin: EdgeInsets.only(bottom: 24.0),
                           height: 50.0,
-                          width: 110.0,
+                          width: 120.0,
                           child: getButton(btnTitle)
                         )
                     ),


### PR DESCRIPTION
Small screen button fix. Issue appear on iPhone 8, slider button didn't display "Get started" fully and button height was narrow.

Fix add width to button, also increase bottom space and change flex to 4.